### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,24 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+const onNoMatchHandler = (req, res) => {
+  const publicErrorObject = new MethodNotAllowedError();
+  res.status(publicErrorObject.statusCode).json(publicErrorObject);
+};
+
+const onErrorHandler = (err, req, res) => {
+  const publicErrorObject = new InternalServerError({
+    statusCode: err.statusCode,
+    cause: err,
+  });
+  console.log(publicErrorObject);
+  res.status(publicErrorObject.statusCode).json(publicErrorObject);
+};
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors.js";
 
 const getNewClient = async () => {
   const client = new Client({
@@ -22,9 +23,11 @@ const query = async (queryObject) => {
     // console.log(result);
     return result;
   } catch (err) {
-    console.log("\nErro dentro do catch do database.js:");
-    console.error(err);
-    throw err;
+    const ServiceErrorObject = new ServiceError({
+      message: "Erro na conexão com o Banco ou na Query.",
+      cause: err,
+    });
+    throw ServiceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,49 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço momentaneamente indisponível.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponivel.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action = "Verifique o método HTTP enviado.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.7",
         "dotenv-expand": "11.0.6",
         "next": "14.2.23",
+        "next-connect": "1.0.0",
         "pg": "8.12.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -2170,6 +2171,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7972,6 +7979,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8891,6 +8911,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.7",
     "dotenv-expand": "11.0.6",
     "next": "14.2.23",
+    "next-connect": "1.0.0",
     "pg": "8.12.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,46 +1,39 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import controller from "infra/controller.js";
 
-const status = async (req, res) => {
-  try {
-    const databaseName = process.env.POSTGRES_DB;
-    const updatedAt = new Date().toISOString();
-    const dbData = await database.query({
-      text: `SELECT version, max_connections, used_connections
+const getHandler = async (req, res) => {
+  const databaseName = process.env.POSTGRES_DB;
+  const updatedAt = new Date().toISOString();
+  const dbData = await database.query({
+    text: `SELECT version, max_connections, used_connections
      FROM
       (SELECT version() AS version) t1,
       (SELECT count(*)::int AS used_connections FROM pg_stat_activity WHERE datname = $1) t2,
       (SELECT setting::int AS max_connections FROM pg_settings WHERE name = 'max_connections') t3
     ;`,
-      values: [databaseName],
-    });
-    const dbVersionValue = await database.query("SHOW server_version;");
+    values: [databaseName],
+  });
+  const dbVersionValue = await database.query("SHOW server_version;");
 
-    const dbVersion = dbVersionValue.rows[0].server_version;
-    // const dbVersion = dbData.rows[0].version;
-    const dbMaxConnections = dbData.rows[0].max_connections;
-    const dbUsedConnections = dbData.rows[0].used_connections;
+  const dbVersion = dbVersionValue.rows[0].server_version;
+  // const dbVersion = dbData.rows[0].version;
+  const dbMaxConnections = dbData.rows[0].max_connections;
+  const dbUsedConnections = dbData.rows[0].used_connections;
 
-    res.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: dbVersion,
-          max_connections: dbMaxConnections,
-          used_connections: dbUsedConnections,
-        },
+  res.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: dbVersion,
+        max_connections: dbMaxConnections,
+        used_connections: dbUsedConnections,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log("\nErro dentro do catch do controller:");
-    console.log(publicErrorObject);
-
-    res.status(500).json(publicErrorObject);
-  }
+    },
+  });
 };
 
-export default status;
+const router = createRouter();
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+// let responseBody = undefined;
+
+describe("POST api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Receive a error response - not allowed method - POST", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action: "Verifique o método HTTP enviado.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowed` e `ServiceError`.
3. Faz o `InternalServerError` aceitar injeção do `statusCode`.